### PR TITLE
increase minimum xios cores to 3

### DIFF
--- a/ece4/generate-job.py
+++ b/ece4/generate-job.py
@@ -211,7 +211,7 @@ def generate_job(kind, config, expname):
             logging.info("Using default 2 nodes configuration for AMIP")
             exp_base[1]['base.context']['job']['oifs']['omp_num_threads'] = 16
             exp_base[1]['base.context']['job']['groups'] = [
-                { 'nodes': 1, 'xios': 1, 'oifs': 5, 'rnfm': 1, 'nemo': 46 },
+                { 'nodes': 1, 'xios': 3, 'oifs': 4, 'rnfm': 1, 'nemo': 60 },
                 { 'nodes': 1, 'oifs': 8 }
             ]
         # default 1 node configuration for OMIP


### PR DESCRIPTION
To run in coupled mode, following a modificatio not very well documented on the portal, it is no longer possible to run with nemo and one single core. I set them up to 3, which is a bit of a waste, but so far seems the best configuration for TL63ORCA2 (more than 215 SYPD). 

